### PR TITLE
Changed LED_PIN to 17

### DIFF
--- a/hw/bsp/samd21/boards/seeeduino_xiao/board.h
+++ b/hw/bsp/samd21/boards/seeeduino_xiao/board.h
@@ -32,7 +32,7 @@
 #endif
 
 // LED
-#define LED_PIN               26
+#define LED_PIN               17
 #define LED_STATE_ON          1
 
 // Button


### PR DESCRIPTION
The LEDs on Seeduino Xiao are connected to PA17, PA18, and PA19:

https://files.seeedstudio.com/wiki/Seeeduino-XIAO/res/Seeeduino-XIAO-v1.0-SCH-191112.pdf

There is no LED on pin 26.